### PR TITLE
Refactor Scooter API and migrate to Neon Cloud DB

### DIFF
--- a/backend/src/main/java/com/scooterrental/backend/entity/Scooter.java
+++ b/backend/src/main/java/com/scooterrental/backend/entity/Scooter.java
@@ -5,6 +5,7 @@ import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
 import lombok.Data;
 import java.math.BigDecimal;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Scooter Entity corresponding to the 'scooters' table.
@@ -19,6 +20,7 @@ public class Scooter {
      * The JDBC driver handles the key retrieval automatically.
      */
     @TableId(type = IdType.AUTO)
+    @JsonProperty("id")
     private Long scooterId;
 
     private String model;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,12 +1,9 @@
 # ==========================================
-# Database Configuration (PostgreSQL)
+# Database Configuration (Neon Cloud PostgreSQL)
 # ==========================================
-# Default PostgreSQL port is 5432
-# Ensure the database name 'scooter_rental' exists in your pgAdmin
-spring.datasource.url=jdbc:postgresql://localhost:5432/ScooterGo_DB
-spring.datasource.username=postgres
-# Replace with your actual PostgreSQL password
-spring.datasource.password=123456
+spring.datasource.url=jdbc:postgresql://ep-sparkling-firefly-abnuwvag-pooler.eu-west-2.aws.neon.tech/neondb?sslmode=require
+spring.datasource.username=neondb_owner
+spring.datasource.password=npg_MUdBoCng53Kv
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # ==========================================


### PR DESCRIPTION
This PR introduces a major architectural upgrade and standardizes the API response format for the frontend.

Key Changes:

Cloud Database Migration: Migrated from local MySQL to Neon Serverless PostgreSQL. The team no longer needs to install local databases or run SQL scripts. The backend will connect to the shared cloud DB automatically.

Standardized API Response: Refactored ScooterController.java to return data wrapped in the standard {"code": 200, "data": [...], "msg": "Success"} format required by the frontend.

Data Mapping Fix: Added @JsonProperty("id") to the Scooter entity to map the database's scooterId to the frontend's expected id field.

English Documentation: Updated all comments in ScooterController.java to English for better maintainability.

Instructions for Frontend Team:

Pull this branch and run the Spring Boot backend.

You do not need to configure a local database. Just run the application.

Hit the GET /api/scooters/available endpoint. You should successfully receive the live test data from the cloud database. Let me know if the map renders correctly!